### PR TITLE
feat(control): add a integrity check to share key

### DIFF
--- a/peerstash-control/peerstash/cli/cmd_id.py
+++ b/peerstash-control/peerstash/cli/cmd_id.py
@@ -27,11 +27,8 @@ def print_id():
     Generate identity string for this node.
     """
     try:
-        # get base64 encoded string
-        payload = identity.generate_identity_payload()
-
         # write share code to std out
-        typer.echo(f"peerstash#{payload}")
+        typer.echo(identity.generate_share_key())
 
     except ValueError as e:
         typer.secho(f"Error: {e}", fg=typer.colors.RED, err=True)

--- a/peerstash-control/peerstash/core/identity.py
+++ b/peerstash-control/peerstash/core/identity.py
@@ -21,7 +21,7 @@ import os
 from .utils import get_file_content
 
 
-def generate_identity_payload() -> str:
+def _generate_identity_payload() -> str:
     """
     Reads keys and returns the raw base64 string
     """
@@ -44,3 +44,9 @@ def generate_identity_payload() -> str:
 
     json_bytes = json.dumps(data).encode("utf-8")
     return base64.b64encode(json_bytes, altchars=b"-_").decode("utf-8")
+
+def generate_share_key() -> str:
+    username = os.environ.get("USER")
+    payload = _generate_identity_payload()
+    
+    return f"peerstash.{username}#{payload}"

--- a/peerstash-control/peerstash/core/registration.py
+++ b/peerstash-control/peerstash/core/registration.py
@@ -98,9 +98,16 @@ def _db_add_host(username) -> None:
 def parse_share_key(share_key: str) -> Dict[str, str]:
     """Decodes the base64 share key."""
     try:
-        clean_key = share_key.split("#")[-1]
+        # decode base64 string
+        check, clean_key = share_key.split("#")
+        check_username = check.split(".")[-1]
         decoded_json = base64.b64decode(clean_key, altchars=b"-_").decode("utf-8")
-        return json.loads(decoded_json)
+        data = json.loads(decoded_json)
+        # check if username in key matches in username data
+        if data["username"] != check_username:
+            raise Exception(f"username does not match hash")
+
+        return data
     except Exception as e:
         raise ValueError(f"Invalid share key: {e}")
 


### PR DESCRIPTION
This adds a sort of checksum to the share key by displaying the username in the share key plain text. This (along with the existing confirmation prompt to overwrite the stored info of the specified user) prevents malicious users from changing the JSON to target someone else's profile to be updated with their own public key.