### PR TITLE
fix(control): free space checker

### DIFF
--- a/peerstash-control/peerstash/core/backup.py
+++ b/peerstash-control/peerstash/core/backup.py
@@ -68,7 +68,7 @@ def _get_free_space(hostname: str, port: int) -> int:
         # Parse output with Regex like the subprocess method
         numbers = re.findall(r"[0-9]+", output)
         if len(numbers) >= 3:
-            free = int(numbers[2])
+            free = int(numbers[2]) * 1024 # df returns number of free KiB
         else:
             raise Exception("Unable to parse output.")
     except Exception as e:
@@ -91,7 +91,7 @@ def _verify_backup_size(name: str) -> tuple[int, int]:
 
     # get added bytes
     res = run_backup(name, True)
-    added_bytes: int = res["total_bytes_processed"]
+    added_bytes: int = res["data_added"]
 
     # return true if there will be space after the backup (for pruning purposes)
     return (free_bytes, added_bytes)


### PR DESCRIPTION
- SFTPGo free space check assumed size was in bytes instead of KiB
- restic dry run free space check was reading processed data instead of data added