### PR TITLE
fix(control): copy known hosts to root upon startup

### DIFF
--- a/peerstash-control/peerstash/setup.py
+++ b/peerstash-control/peerstash/setup.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import shutil
 import socket
 import sqlite3
 import sys


### PR DESCRIPTION
This PR fixes a critical bug that prevents the backups from running after the container shuts down and comes back up.