### PR TITLE
fix(control): use versioning via CI

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -46,7 +46,9 @@
           "CHANGELOG.md",
           "package.json",
           "peerstash-*/package.json",
-          "peerstash-compose/docker-compose.yml"
+          "peerstash-compose/docker-compose.yml",
+          "peerstash-control/pyproject.toml",
+          "peerstash-control/peerstash/cli/__init__.py"
         ],
         "message": "chore(release): peerstash-v${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }

--- a/peerstash-control/.releaserc.json
+++ b/peerstash-control/.releaserc.json
@@ -40,6 +40,20 @@
               }
             ],
             "countMatches": true
+          },
+          {
+            "files": ["peerstash/cli/__init__.py"],
+            "from": "__version__ = (.*)",
+            "to": "__version__ = \"${nextRelease.version}\"",
+            "results": [
+              {
+                "file": "peerstash/cli/__init__.py",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ],
+            "countMatches": true
           }
         ]
       }

--- a/peerstash-control/peerstash/cli/__init__.py
+++ b/peerstash-control/peerstash/cli/__init__.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+__version__ = "0.1.0"
+
 import typer
 
 from peerstash.cli import (cmd_backup, cmd_cancel, cmd_evict, cmd_id, cmd_list,


### PR DESCRIPTION
This PR sets up a versioning schema that is updated by the GitHub Actions workflow. A future PR will add a `--version` option to the CLI tool.