### PR TITLE
fix(control): make --version a top-level command option

### DIFF
--- a/peerstash-control/peerstash/cli/__init__.py
+++ b/peerstash-control/peerstash/cli/__init__.py
@@ -36,7 +36,7 @@ def version_callback(value: bool):
 app = typer.Typer(help="PeerStash CLI Tool",no_args_is_help=True)
 
 
-@app.callback()
+@app.callback(invoke_without_command=True)
 def cli(
     version: Annotated[
         bool | None,


### PR DESCRIPTION
Allows for `peerstash --version` instead of requiring `peerstash cli --version`